### PR TITLE
Adicao modulo PJ e correcao de erro de cadastro de NULL nas listas de…

### DIFF
--- a/BancoRoxinho/BancoRoxinho.Dominio/Model/PessoaJuridica.cs
+++ b/BancoRoxinho/BancoRoxinho.Dominio/Model/PessoaJuridica.cs
@@ -1,13 +1,60 @@
 ﻿using System;
+using CPFCNPJ;
+using BancoRoxinho.Dominio.Dados;
 
 namespace BancoRoxinho.Dominio.Model
 {
-    // Pessoa Juridica herda Pessoa
     public class PessoaJuridica : Pessoa
     {
+        public string CNPJ = "";
+        public string Nome;
+
+        bool VerificarCNPJ(string cnpjASerValidado)
+        {
+            var verificadorCNPJ = new Main();
+            return verificadorCNPJ.IsValidCPFCNPJ(cnpjASerValidado);
+            
+        }
+
+        bool CNPJJaFoiCadastrado(string cnpjASerValidado)
+        {
+            var listaPJs = PessoasRepository.PessoaJuridicas;
+            foreach (var pj in listaPJs)
+            {
+                if (pj.CNPJ == cnpjASerValidado)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public PessoaJuridica CadastrarPessoa()
         {
-            throw new NotImplementedException();
+            var pessoa = new PessoaJuridica();
+            Console.WriteLine("Digite o nome da empresa: ");
+            pessoa.Nome = Console.ReadLine();
+
+            Console.WriteLine("Digite o CNPJ de " + pessoa.Nome + ":");
+            pessoa.CNPJ = Console.ReadLine();
+
+            bool cnpjValido = VerificarCNPJ(pessoa.CNPJ);
+            if (!cnpjValido)
+            {
+                Console.WriteLine("\nCNPJ inválido.\n");
+                return null;
+            }
+
+            if (CNPJJaFoiCadastrado(pessoa.CNPJ))
+            {
+                Console.WriteLine("\nCNPJ já cadastrado\n");
+                return null;
+            }
+            
+            Console.Clear();
+
+            return pessoa;
         }
     }
 }

--- a/BancoRoxinho/BancoRoxinho.Dominio/Program.cs
+++ b/BancoRoxinho/BancoRoxinho.Dominio/Program.cs
@@ -17,6 +17,8 @@ namespace BancoRoxinho.Dominio
                 Console.WriteLine("Escolha um número para prosseguir:");
                 Console.WriteLine("1 - Cadastrar pessoa física");
                 Console.WriteLine("2 - Ler pessoas físicas cadastrada");
+                Console.WriteLine("3 - Cadastrar pessoa jurídica");
+                Console.WriteLine("4 - Ler pessoas jurídicas");
                 Console.WriteLine("0 - Sair");
 
                 int escolhaDoUsuario = int.Parse(Console.ReadLine());
@@ -31,6 +33,12 @@ namespace BancoRoxinho.Dominio
                         break;
                     case 2:
                         EscolheuAOpcaoDeVerPessoasFisicas();
+                        break;
+                    case 3:
+                        EscolheuAOpcaoCadastrarPJ();
+                        break;
+                    case 4:
+                        EscolheuAOpcaoDeVerPJs();
                         break;
                     case 0:
                     default: //padrão
@@ -69,7 +77,34 @@ namespace BancoRoxinho.Dominio
             var pessoa = new PessoaFisica();
             var pessoaCadastrada = pessoa.CadastrarPessoa();
 
-            PessoasRepository.PessoasFisicas.Add(pessoaCadastrada);
+            if (pessoaCadastrada != null)
+            {
+                PessoasRepository.PessoasFisicas.Add(pessoaCadastrada);
+            }
         }
+
+        static void EscolheuAOpcaoCadastrarPJ()
+        {
+            var pj = new PessoaJuridica();
+            var pjCadastrada = pj.CadastrarPessoa();
+
+            if (pjCadastrada != null)
+            {
+               PessoasRepository.PessoaJuridicas.Add(pjCadastrada);
+            }
+        }
+
+        static void EscolheuAOpcaoDeVerPJs()
+        {
+            var listaPJs = PessoasRepository.PessoaJuridicas;
+
+            foreach(var pessoa in listaPJs)
+            {
+                Console.WriteLine("\nEmpresa: " + pessoa.Nome);
+                Console.WriteLine("CNPJ: "+pessoa.CNPJ+"\n");
+            }
+
+        }
+
     }
 }


### PR DESCRIPTION
Oi, Vitor!

1) Implementei a parte de pessoa jurídica verificando se, no cadastramento, o CNPJ já foi cadastrado anteriormente.

2) Detectei e corrigi (espero rs) um erro no cadastramento de pessoas.
Quando o cadastramento é rejeitado por alguma inconsistência (menor de idade, CPF ou CNPJ inválido etc), 
é gravado um registro na lista com conteúdo NULL o que ocasiona erro nas opções de listar as pessoas cadastradas.